### PR TITLE
Require non-hashes and non-arrays to be scalars

### DIFF
--- a/lib/Brannigan/Tree.pm
+++ b/lib/Brannigan/Tree.pm
@@ -269,6 +269,7 @@ sub _validate_param {
 	} elsif ($validations->{array}) {
 		return $self->_validate_array($param, $value, $validations);
 	} else {
+		return ['scalar(1)'] if defined $value && ref $value;
 		return $self->_validate_scalar($param, $value, $validations);
 	}
 }


### PR DESCRIPTION
Same patch as https://rt.cpan.org/Public/Bug/Display.html?id=124269 - reposting it here, as I don't know if the CPAN RT is still being checked; The module POD points to CPAN RT, but the package metadata to this git repo, hence my confusion.